### PR TITLE
fix(gateway-form): set default values for inputs, select, and switch to avoid uncontrolled warning

### DIFF
--- a/src/sections/payment-gateway/settings-gateway-forms/gateway-form.tsx
+++ b/src/sections/payment-gateway/settings-gateway-forms/gateway-form.tsx
@@ -28,15 +28,13 @@ export function GatewayForm({
   buttonText,
   name,
 }: GatewayFormProps & { name: GatewayType }) {
-  const defaultValues: Record<string, any> = fields.reduce(
-    (acc, f) => {
-      acc[f.id] = "";
-      return acc;
-    },
-    {} as Record<string, any>
-  );
+  const defaultValues: Record<string, any> = {};
 
-  if (selectField) defaultValues[selectField.id] = "";
+  fields.forEach((f) => {
+    defaultValues[f.id] = ""; // texto y textarea siempre ""
+  });
+
+  if (selectField) defaultValues[selectField.id] = "sandbox";
   if (switchField) defaultValues[switchField.id] = false;
 
   const schema = gatewaysSchemas[name] as ZodTypeAny;
@@ -99,6 +97,7 @@ export function GatewayForm({
                     type={f.type || "text"}
                     placeholder={f.placeholder || ""}
                     {...field}
+                    value={field.value ?? ""}
                     className="dark:bg-gray-800 dark:text-gray-100 dark:placeholder-gray-400 dark:border-gray-700 px-3 py-2"
                   />
                   {errors[f.id] && (
@@ -123,7 +122,10 @@ export function GatewayForm({
               <Label htmlFor={selectField.id} className="dark:text-gray-200">
                 {selectField.label}
               </Label>
-              <Select value={field.value} onValueChange={field.onChange}>
+              <Select
+                value={field.value ?? "sandbox"}
+                onValueChange={field.onChange}
+              >
                 <SelectTrigger className="dark:text-white">
                   <SelectValue placeholder="Select..." />
                 </SelectTrigger>


### PR DESCRIPTION
# Fix GatewayForm: Ensure Controlled Inputs and Initialize Select with "sandbox"

## Description

This PR fixes React warnings related to uncontrolled inputs and selects in the `GatewayForm` component. The changes include:

- Initialize all text and textarea fields with `""` to make them controlled.
- Initialize the `Select` field with `"sandbox"` as the default value.
- Initialize `Switch` fields with `false` as the default value.
- Update `Controller` components to ensure `value` or `checked` are never `undefined`.

These changes remove React warnings about inputs switching from uncontrolled to controlled and ensure consistent form behavior.
